### PR TITLE
Use GPIO_NUM_* values instead of ints

### DIFF
--- a/include/u8g2_esp32_hal.h
+++ b/include/u8g2_esp32_hal.h
@@ -15,7 +15,7 @@
 #include "driver/i2c.h"
 #include "driver/spi_master.h"
 
-#define U8G2_ESP32_HAL_UNDEFINED (-1)
+#define U8G2_ESP32_HAL_UNDEFINED GPIO_NUM_NC
 
 #define I2C_MASTER_NUM I2C_NUM_1     //  I2C port number for master dev
 #define I2C_MASTER_TX_BUF_DISABLE 0  //  I2C master do not need buffer

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -61,9 +61,9 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       memset(&bus_config, 0, sizeof(spi_bus_config_t));
       bus_config.sclk_io_num = u8g2_esp32_hal.clk;   // CLK
       bus_config.mosi_io_num = u8g2_esp32_hal.mosi;  // MOSI
-      bus_config.miso_io_num = -1;                   // MISO
-      bus_config.quadwp_io_num = -1;                 // Not used
-      bus_config.quadhd_io_num = -1;                 // Not used
+      bus_config.miso_io_num = GPIO_NUM_NC;          // MISO
+      bus_config.quadwp_io_num = GPIO_NUM_NC;        // Not used
+      bus_config.quadhd_io_num = GPIO_NUM_NC;        // Not used
       // ESP_LOGI(TAG, "... Initializing bus.");
       ESP_ERROR_CHECK(spi_bus_initialize(HSPI_HOST, &bus_config, 1));
 


### PR DESCRIPTION
These updates prevent this the following: `error: invalid conversion from 'int' to 'gpio_num_t'` when compiliing