### PR TITLE
Fix build issues on esp32-idf v5.

### DIFF
--- a/include/u8g2_esp32_hal.h
+++ b/include/u8g2_esp32_hal.h
@@ -17,7 +17,12 @@
 
 #define U8G2_ESP32_HAL_UNDEFINED (-1)
 
+#if SOC_I2C_NUM > 1
 #define I2C_MASTER_NUM I2C_NUM_1     //  I2C port number for master dev
+#else
+#define I2C_MASTER_NUM I2C_NUM_0     //  I2C port number for master dev
+#endif
+
 #define I2C_MASTER_TX_BUF_DISABLE 0  //  I2C master do not need buffer
 #define I2C_MASTER_RX_BUF_DISABLE 0  //  I2C master do not need buffer
 #define I2C_MASTER_FREQ_HZ 50000     //  I2C master clock frequency

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -16,6 +16,12 @@ static spi_device_handle_t handle_spi;   // SPI handle.
 static i2c_cmd_handle_t handle_i2c;      // I2C handle.
 static u8g2_esp32_hal_t u8g2_esp32_hal;  // HAL state data.
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0)
+#define HOST    HSPI_HOST
+#else
+#define HOST    SPI2_HOST
+#endif
+
 #undef ESP_ERROR_CHECK
 #define ESP_ERROR_CHECK(x)                   \
   do {                                       \
@@ -65,7 +71,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       bus_config.quadwp_io_num = -1;                 // Not used
       bus_config.quadhd_io_num = -1;                 // Not used
       // ESP_LOGI(TAG, "... Initializing bus.");
-      ESP_ERROR_CHECK(spi_bus_initialize(HSPI_HOST, &bus_config, 1));
+      ESP_ERROR_CHECK(spi_bus_initialize(HOST, &bus_config, 1));
 
       spi_device_interface_config_t dev_config;
       dev_config.address_bits = 0;
@@ -82,7 +88,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       dev_config.pre_cb = NULL;
       dev_config.post_cb = NULL;
       // ESP_LOGI(TAG, "... Adding device bus.");
-      ESP_ERROR_CHECK(spi_bus_add_device(HSPI_HOST, &dev_config, &handle_spi));
+      ESP_ERROR_CHECK(spi_bus_add_device(HOST, &dev_config, &handle_spi));
 
       break;
     }
@@ -176,7 +182,7 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
       ESP_LOGD(TAG, "End I2C transfer.");
       ESP_ERROR_CHECK(i2c_master_stop(handle_i2c));
       ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_MASTER_NUM, handle_i2c,
-                                           I2C_TIMEOUT_MS / portTICK_RATE_MS));
+                                           pdMS_TO_TICKS(I2C_TIMEOUT_MS)));
       i2c_cmd_link_delete(handle_i2c);
       break;
     }

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -16,11 +16,7 @@ static spi_device_handle_t handle_spi;   // SPI handle.
 static i2c_cmd_handle_t handle_i2c;      // I2C handle.
 static u8g2_esp32_hal_t u8g2_esp32_hal;  // HAL state data.
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0)
-#define HOST    HSPI_HOST
-#else
 #define HOST    SPI2_HOST
-#endif
 
 #undef ESP_ERROR_CHECK
 #define ESP_ERROR_CHECK(x)                   \


### PR DESCRIPTION
This commit is to fix a few issues:

- The I2C_MASTER_NUM definition when the module doesn't have 2 I2C, such as esp32-c3.
- The HSPI_HOST macro is deprecated for later esp modules, such as s3, so defined a new macro to make sure it works for later modules.
- portTICK_RATE_MS is removed in latest freertos, and from their [doc](https://www.freertos.org/fr-content-src/uploads/2018/07/FreeRTOS_Reference_Manual_V10.0.0.pdf), pdMS_TO_TICKS should be the preferred way, hence updating it.