### PR TITLE
Initialize variables, add override_freq_hz

### DIFF
--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -59,8 +59,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
         break;
       }
 
-      spi_bus_config_t bus_config;
-      memset(&bus_config, 0, sizeof(spi_bus_config_t));
+      spi_bus_config_t bus_config = {0};
       bus_config.sclk_io_num = u8g2_esp32_hal.bus.spi.clk;   // CLK
       bus_config.mosi_io_num = u8g2_esp32_hal.bus.spi.mosi;  // MOSI
       bus_config.miso_io_num = GPIO_NUM_NC;                  // MISO
@@ -69,7 +68,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       // ESP_LOGI(TAG, "... Initializing bus.");
       ESP_ERROR_CHECK(spi_bus_initialize(HOST, &bus_config, 1));
 
-      spi_device_interface_config_t dev_config;
+      spi_device_interface_config_t dev_config = {0};
       dev_config.address_bits = 0;
       dev_config.command_bits = 0;
       dev_config.dummy_bits = 0;
@@ -90,7 +89,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
     }
 
     case U8X8_MSG_BYTE_SEND: {
-      spi_transaction_t trans_desc;
+      spi_transaction_t trans_desc = {0};
       trans_desc.addr = 0;
       trans_desc.cmd = 0;
       trans_desc.flags = 0;
@@ -98,7 +97,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       trans_desc.rxlength = 0;
       trans_desc.tx_buffer = arg_ptr;
       trans_desc.rx_buffer = NULL;
-
+      // trans_desc.override_freq_hz = 0; // this param does not exist prior to ESP-IDF 5.5.0
       // ESP_LOGI(TAG, "... Transmitting %d bytes.", arg_int);
       ESP_ERROR_CHECK(spi_device_transmit(handle_spi, &trans_desc));
       break;


### PR DESCRIPTION
override_freq_hz was added in ESP-IDF 5.5.0, and passing uninitialized garbage to it causes the SPI clock to peg at the APB clock frequency

This resolves issue #19