### PR TITLE
Use SPI_DMA_CH_AUTO for selecting DMA.

### DIFF
--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -16,7 +16,7 @@ static spi_device_handle_t handle_spi;   // SPI handle.
 static i2c_cmd_handle_t handle_i2c;      // I2C handle.
 static u8g2_esp32_hal_t u8g2_esp32_hal;  // HAL state data.
 
-#define HOST    SPI2_HOST
+#define HOST SPI2_HOST
 
 #undef ESP_ERROR_CHECK
 #define ESP_ERROR_CHECK(x)                   \
@@ -66,7 +66,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       bus_config.quadwp_io_num = GPIO_NUM_NC;                // Not used
       bus_config.quadhd_io_num = GPIO_NUM_NC;                // Not used
       // ESP_LOGI(TAG, "... Initializing bus.");
-      ESP_ERROR_CHECK(spi_bus_initialize(HOST, &bus_config, 1));
+      ESP_ERROR_CHECK(spi_bus_initialize(HOST, &bus_config, SPI_DMA_CH_AUTO));
 
       spi_device_interface_config_t dev_config = {0};
       dev_config.address_bits = 0;
@@ -97,8 +97,8 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
       trans_desc.rxlength = 0;
       trans_desc.tx_buffer = arg_ptr;
       trans_desc.rx_buffer = NULL;
-      // trans_desc.override_freq_hz = 0; // this param does not exist prior to ESP-IDF 5.5.0
-      // ESP_LOGI(TAG, "... Transmitting %d bytes.", arg_int);
+      // trans_desc.override_freq_hz = 0; // this param does not exist prior to
+      // ESP-IDF 5.5.0 ESP_LOGI(TAG, "... Transmitting %d bytes.", arg_int);
       ESP_ERROR_CHECK(spi_device_transmit(handle_spi, &trans_desc));
       break;
     }


### PR DESCRIPTION
For esp32c3 this does not compile.  Setting the dma to SPI_DMA_CH_AUTO fixes it.
This should be valid for other esp versions too.