### PR TITLE
Adds V2 I2C API support

### DIFF
--- a/include/u8g2_esp32_hal.h
+++ b/include/u8g2_esp32_hal.h
@@ -12,7 +12,7 @@
 #include "u8g2.h"
 
 #include "driver/gpio.h"
-#include "driver/i2c.h"
+#include "driver/i2c_master.h"
 #include "driver/spi_master.h"
 
 #define U8G2_ESP32_HAL_UNDEFINED GPIO_NUM_NC

--- a/include/u8g2_esp32_hal.h
+++ b/include/u8g2_esp32_hal.h
@@ -12,7 +12,14 @@
 #include "u8g2.h"
 
 #include "driver/gpio.h"
+
+#if ((defined CONFIG_I2C_ENABLE_SLAVE_DRIVER_VERSION_2 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)))
+#define U8G2_ESP32_HAL_USE_V2_I2C_API
 #include "driver/i2c_master.h"
+#else
+#include "driver/i2c.h"
+#endif
+
 #include "driver/spi_master.h"
 
 #define U8G2_ESP32_HAL_UNDEFINED GPIO_NUM_NC

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -107,7 +107,6 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t* u8x8,
   return 0;
 }  // u8g2_esp32_spi_byte_cb
 
-#define I2C_ADDRESS 0x3c
 #define BYTES_BUFFER_LEN 100
 uint8_t bytes_buffer[BYTES_BUFFER_LEN] = {0};
 uint8_t* bytes_buffer_ptr = bytes_buffer;
@@ -139,20 +138,25 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
       i2c_master_bus_config_t bus_conf_i2c = {
         .clk_source = I2C_CLK_SRC_DEFAULT,
         .glitch_ignore_cnt = 7,
-        .i2c_port = I2C_NUM_0,
-        .scl_io_num = 32,
-        .sda_io_num = 33,
+        .i2c_port = I2C_MASTER_NUM,
+        .scl_io_num = u8g2_esp32_hal.bus.i2c.scl,
+        .sda_io_num = u8g2_esp32_hal.bus.i2c.sda,
         .flags.enable_internal_pullup = true,
       };
+      ESP_LOGI(TAG, "sda_io_num %d", u8g2_esp32_hal.bus.i2c.sda);
+      ESP_LOGI(TAG, "scl_io_num %d", u8g2_esp32_hal.bus.i2c.scl);
+      ESP_LOGI(TAG, "i2c_port %d", I2C_MASTER_NUM);
 
+      uint8_t i2c_address = u8x8_GetI2CAddress(u8x8);
       ESP_ERROR_CHECK(i2c_new_master_bus(&bus_conf_i2c, &bus_handle_i2c));
-      ESP_ERROR_CHECK(i2c_master_probe(bus_handle_i2c, I2C_ADDRESS, -1));
 
       i2c_device_config_t dev_conf_i2c = {
         .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = I2C_ADDRESS,
+        .device_address = i2c_address,
         .scl_speed_hz = I2C_MASTER_FREQ_HZ,
       };
+      ESP_LOGI(TAG, "i2c_device_address 0x%02x", i2c_address);
+      ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_FREQ_HZ);
 
       ESP_ERROR_CHECK(i2c_master_bus_add_device(bus_handle_i2c, &dev_conf_i2c, &dev_handle_i2c));
       break;
@@ -160,17 +164,20 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
 
     case U8X8_MSG_BYTE_SEND: {
       uint8_t* data_ptr = (uint8_t*)arg_ptr;
+      ESP_LOG_BUFFER_HEXDUMP(TAG, data_ptr, arg_int, ESP_LOG_VERBOSE);
       memcpy(bytes_buffer_ptr,data_ptr,arg_int);
       bytes_buffer_ptr += arg_int;
       break;
     }
 
     case U8X8_MSG_BYTE_START_TRANSFER: {
+      ESP_LOGD(TAG, "Start I2C transfer to %02X.", u8x8_GetI2CAddress(u8x8) >> 1);
       bytes_buffer_ptr = bytes_buffer;
       break;
     }
 
     case U8X8_MSG_BYTE_END_TRANSFER: {
+      ESP_LOGD(TAG, "End I2C transfer.");
       ESP_ERROR_CHECK(i2c_master_transmit(dev_handle_i2c, bytes_buffer,bytes_buffer_ptr - bytes_buffer,I2C_TIMEOUT_MS));
       break;
     }

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -12,13 +12,19 @@
 static const char* TAG = "u8g2_hal";
 static const unsigned int I2C_TIMEOUT_MS = 1000;
 
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
 #define I2C_BYTES_BUFFER_LEN 100
 uint8_t i2c_bytes_buffer[I2C_BYTES_BUFFER_LEN] = {0};
 uint8_t* i2c_bytes_buffer_ptr = i2c_bytes_buffer;
+#endif
 
 static spi_device_handle_t handle_spi;   // SPI handle.
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
 static i2c_master_bus_handle_t bus_handle_i2c;      // I2C handle.
 static i2c_master_dev_handle_t dev_handle_i2c;      // I2C handle.
+#else
+static i2c_cmd_handle_t handle_i2c;      // I2C handle.
+#endif
 static u8g2_esp32_hal_t u8g2_esp32_hal;  // HAL state data.
 
 #define HOST    SPI2_HOST
@@ -136,6 +142,7 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
         break;
       }
 
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
       i2c_master_bus_config_t bus_conf_i2c = {
         .clk_source = I2C_CLK_SRC_DEFAULT,
         .glitch_ignore_cnt = 7,
@@ -160,26 +167,74 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
       ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_FREQ_HZ);
 
       ESP_ERROR_CHECK(i2c_master_bus_add_device(bus_handle_i2c, &dev_conf_i2c, &dev_handle_i2c));
+#else
+      i2c_config_t conf = {0};
+      conf.mode = I2C_MODE_MASTER;
+      ESP_LOGI(TAG, "sda_io_num %d", u8g2_esp32_hal.bus.i2c.sda);
+      conf.sda_io_num = u8g2_esp32_hal.bus.i2c.sda;
+      conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+      ESP_LOGI(TAG, "scl_io_num %d", u8g2_esp32_hal.bus.i2c.scl);
+      conf.scl_io_num = u8g2_esp32_hal.bus.i2c.scl;
+      conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+      ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_FREQ_HZ);
+      conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
+      ESP_LOGI(TAG, "i2c_param_config %d", conf.mode);
+      ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &conf));
+      ESP_LOGI(TAG, "i2c_driver_install %d", I2C_MASTER_NUM);
+      ESP_ERROR_CHECK(i2c_driver_install(I2C_MASTER_NUM, conf.mode,
+                                         I2C_MASTER_RX_BUF_DISABLE,
+                                         I2C_MASTER_TX_BUF_DISABLE, 0));
+#endif
+
       break;
     }
 
     case U8X8_MSG_BYTE_SEND: {
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
       uint8_t* data_ptr = (uint8_t*)arg_ptr;
       ESP_LOG_BUFFER_HEXDUMP(TAG, data_ptr, arg_int, ESP_LOG_VERBOSE);
       memcpy(i2c_bytes_buffer_ptr,data_ptr,arg_int);
       i2c_bytes_buffer_ptr += arg_int;
+#else
+      uint8_t* data_ptr = (uint8_t*)arg_ptr;
+      ESP_LOG_BUFFER_HEXDUMP(TAG, data_ptr, arg_int, ESP_LOG_VERBOSE);
+
+      while (arg_int > 0) {
+        ESP_ERROR_CHECK(
+            i2c_master_write_byte(handle_i2c, *data_ptr, ACK_CHECK_EN));
+        data_ptr++;
+        arg_int--;
+      }
+#endif
       break;
     }
 
     case U8X8_MSG_BYTE_START_TRANSFER: {
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
       ESP_LOGD(TAG, "Start I2C transfer to %02X.", u8x8_GetI2CAddress(u8x8) >> 1);
       i2c_bytes_buffer_ptr = i2c_bytes_buffer;
+#else
+      uint8_t i2c_address = u8x8_GetI2CAddress(u8x8);
+      handle_i2c = i2c_cmd_link_create();
+      ESP_LOGD(TAG, "Start I2C transfer to %02X.", i2c_address >> 1);
+      ESP_ERROR_CHECK(i2c_master_start(handle_i2c));
+      ESP_ERROR_CHECK(i2c_master_write_byte(
+          handle_i2c, i2c_address | I2C_MASTER_WRITE, ACK_CHECK_EN));
+#endif
       break;
     }
 
     case U8X8_MSG_BYTE_END_TRANSFER: {
+#ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
       ESP_LOGD(TAG, "End I2C transfer.");
       ESP_ERROR_CHECK(i2c_master_transmit(dev_handle_i2c, i2c_bytes_buffer,i2c_bytes_buffer_ptr - i2c_bytes_buffer,I2C_TIMEOUT_MS));
+#else
+      ESP_LOGD(TAG, "End I2C transfer.");
+      ESP_ERROR_CHECK(i2c_master_stop(handle_i2c));
+      ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_MASTER_NUM, handle_i2c,
+                                           pdMS_TO_TICKS(I2C_TIMEOUT_MS)));
+      i2c_cmd_link_delete(handle_i2c);
+#endif
       break;
     }
   }

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -160,10 +160,14 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
 
       i2c_device_config_t dev_conf_i2c = {
         .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = i2c_address,
+        // Bit shift by one to make it consistant with the old API
+        // which requires takes an address with the LSB (leftmost) bit being
+        // the read/write bit versus the new one which only takes the address
+        // unshifted
+        .device_address = i2c_address >> 1,
         .scl_speed_hz = I2C_MASTER_FREQ_HZ,
       };
-      ESP_LOGI(TAG, "i2c_device_address 0x%02x", i2c_address);
+      ESP_LOGI(TAG, "i2c_device_address 0x%02X", i2c_address >> 1);
       ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_FREQ_HZ);
 
       ESP_ERROR_CHECK(i2c_master_bus_add_device(bus_handle_i2c, &dev_conf_i2c, &dev_handle_i2c));

--- a/src/u8g2_esp32_hal.c
+++ b/src/u8g2_esp32_hal.c
@@ -197,6 +197,15 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t* u8x8,
 #ifdef U8G2_ESP32_HAL_USE_V2_I2C_API
       uint8_t* data_ptr = (uint8_t*)arg_ptr;
       ESP_LOG_BUFFER_HEXDUMP(TAG, data_ptr, arg_int, ESP_LOG_VERBOSE);
+      if(i2c_bytes_buffer_ptr - i2c_bytes_buffer + arg_int > I2C_BYTES_BUFFER_LEN){
+        ESP_LOGE(
+          TAG,
+          "The i2c message is too large for the bytes buffer. \
+          Current length required is %u but allocated is %u.",
+          i2c_bytes_buffer_ptr - i2c_bytes_buffer + arg_int,
+          I2C_BYTES_BUFFER_LEN
+        );
+      }
       memcpy(i2c_bytes_buffer_ptr,data_ptr,arg_int);
       i2c_bytes_buffer_ptr += arg_int;
 #else


### PR DESCRIPTION
Espressif added a new API for I2C which cannot be used with the old one. Some I2C libraries already use V2 so using them along side u8g2-hal-esp-idf is not possible. In this PR I added support for the V2 API while retaining backwards compatibility. If the V2 is enabled then it will be used.